### PR TITLE
Adjust arity of FROM operation in custom dockerfile

### DIFF
--- a/Dockerfiles/Custom
+++ b/Dockerfiles/Custom
@@ -1,4 +1,5 @@
-FROM amazonlinux:latest #Official amazon linux AMI
+# Official amazon linux AMI
+FROM amazonlinux:latest
 
 ################################################################################
 #                             INSTALL PYTHON 3.6                               #


### PR DESCRIPTION
On some versions of Docker (e.g. Docker version 17.09.0-ce, build afdb6d4) the Dockerfiles/Custom source throws the following error:

    docker build -f ./Dockerfiles/Custom -t lambda:tiler .
    Sending build context to Docker daemon  191.5kB
    Step 1/39 : FROM amazonlinux:latest #Official amazon linux AMI
    FROM requires either one or three arguments
    make: *** [build-custom] Error 1

This works around the limitations of inline comments with some Docker versions.