### PR TITLE
rename handler app.sentinel.APP

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -38,7 +38,7 @@ package:
 
 functions:
   sentinel-tiler:
-    handler: app.sentinel.SENTINEL_APP
+    handler: app.sentinel.APP
     memorySize: 1536
     timeout: 20
     events:


### PR DESCRIPTION
Method was renamed from to [SENTINEL_APP](https://github.com/mapbox/sentinel-tiler/blob/master/app/sentinel.py#L15) to APP